### PR TITLE
Add Symfony log rotation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ La librairie `symfony/process` est utilisé pour faire cette parallélisation.
 * `gsynchro:add-sequence` : Créer une séquence
 * `gsynchro:create-ftp-folders` : Crée la structure des dossiers pour le ftp
 * `gsynchro:execute` : Lancer un import, un export ou une séquence
+* `gsynchro:log-rotate` : Compresser les logs dépassant 100Mo
 
 Utilisation pour la crontab notamment `php bin/console gsynchro:execute MonImport`
 

--- a/config/services.yml
+++ b/config/services.yml
@@ -35,6 +35,10 @@ services:
         class: Griiv\SynchroEngine\Command\ExecuteCommand
         tags: [ console.command ]
 
+    griiv.synchro.console.log.rotate.command:
+        class: Griiv\SynchroEngine\Command\LogRotateCommand
+        tags: [ console.command ]
+
 
     #services
 

--- a/src/Command/LogRotateCommand.php
+++ b/src/Command/LogRotateCommand.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * This file is part of the Symfony package.
+ *
+ * (c) Arnaud Scoté <arnaud@griiv.fr>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ **/
+
+namespace Griiv\SynchroEngine\Command;
+
+use Griiv\SynchroEngine\Core\Helpers\SynchroHelper;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Finder\Finder;
+use Symfony\Component\Filesystem\Filesystem;
+
+final class LogRotateCommand extends Command
+{
+    /**
+     * @var Filesystem
+     */
+    private $fs;
+
+    /**
+     * @var Finder
+     */
+    private $finder;
+
+    public function __construct($name = null)
+    {
+        parent::__construct($name);
+        $this->fs = new Filesystem();
+        $this->finder = new Finder();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure(): void
+    {
+        $this
+            ->setName('gsynchro:log-rotate')
+            ->setDescription('Compress log files larger than 100MB in logs directory');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $logsPath = SynchroHelper::getLogsPath();
+        if (!$this->fs->exists($logsPath)) {
+            $io->error(sprintf('Logs path "%s" does not exist', $logsPath));
+            return 1;
+        }
+
+        $this->finder->files()->name('*.log')->in($logsPath);
+        if ($this->finder->count() === 0) {
+            $io->warning('No log files found');
+            return 0;
+        }
+
+        foreach ($this->finder as $file) {
+            $this->compressFile($file->getRealPath());
+        }
+
+        $io->success('Logs rotated');
+        return 0;
+    }
+
+    private function compressFile(string $filePath): void
+    {
+        if (!$this->fs->exists($filePath)) {
+            return;
+        }
+
+        $threshold = 100 * 1024 * 1024; // 100 MB
+        if (filesize($filePath) < $threshold) {
+            return;
+        }
+
+        $gzFile = $filePath . '.' . date('YmdHis') . '.gz';
+        $in = fopen($filePath, 'rb');
+        $out = gzopen($gzFile, 'wb9');
+        if ($in && $out) {
+            while (!feof($in)) {
+                gzwrite($out, fread($in, 1024 * 512));
+            }
+        }
+        if ($in) {
+            fclose($in);
+        }
+        if ($out) {
+            gzclose($out);
+        }
+
+        $this->fs->remove($filePath);
+        $this->fs->touch($filePath);
+    }
+}


### PR DESCRIPTION
## Summary
- add `LogRotateCommand` to rotate log files
- gzip logs bigger than 100MB

## Testing
- `php bin/console gsynchro:log-rotate`
