### PR TITLE
Use Symfony ParameterBag for global parameters

### DIFF
--- a/bin/batchSynchro.php
+++ b/bin/batchSynchro.php
@@ -11,6 +11,8 @@
 require_once __DIR__ . '/../../../config/config.inc.php';
 require_once __DIR__ .'/../vendor/autoload.php';
 
+use Symfony\Component\HttpFoundation\ParameterBag;
+
 define("STATUS_OK", "OK");
 define("STATUS_BREAK", "BREAK");
 define("STATUS_END", "END");
@@ -33,7 +35,12 @@ if ($module) {
     $arguments = $argv[0];
 }
 
-$globalParameters = isset($arguments['globalParameters']) ? $arguments['globalParameters'] : array();
+$globalParameters = $arguments['globalParameters'] ?? new ParameterBag();
+if (is_array($globalParameters)) {
+    $globalParameters = new ParameterBag($globalParameters);
+} elseif (!$globalParameters instanceof ParameterBag) {
+    $globalParameters = new ParameterBag();
+}
 
 // Make method parameters array
 $methodParameters = isset($arguments['methodParameters']) ? $arguments['methodParameters'] : array();

--- a/src/Core/ExecutableBase.php
+++ b/src/Core/ExecutableBase.php
@@ -15,6 +15,7 @@ use PrestaShop\PrestaShop\Core\Util\DateTime\DateTime;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Process\PhpExecutableFinder;
 use Symfony\Component\Process\Process;
+use Symfony\Component\HttpFoundation\ParameterBag;
 
 abstract class ExecutableBase
 {
@@ -31,16 +32,16 @@ abstract class ExecutableBase
     protected $moduleName = 'griivsynchroengine';
 
     /**
-     * @var array
+     * @var ParameterBag
      */
-    protected $globalParameters = array();
+    protected ParameterBag $globalParameters;
 
-    public function __construct(array $globalParameters = [])
+    public function __construct(ParameterBag $globalParameters = null)
     {
         $logger = $this->initLogger();
 
         $this->setLogger($logger);
-        $this->setGlobalParameters($globalParameters);
+        $this->setGlobalParameters($globalParameters ?? new ParameterBag());
     }
 
     public function __destruct()
@@ -75,7 +76,7 @@ abstract class ExecutableBase
         }
     }
 
-    public function getGlobalParameters(): array
+    public function getGlobalParameters(): ParameterBag
     {
         return $this->globalParameters;
     }
@@ -86,15 +87,15 @@ abstract class ExecutableBase
      */
     public function getGlobalParameter($parameterName)
     {
-        return $this->globalParameters[$parameterName] ?? null;
+        return $this->globalParameters->get($parameterName);
     }
 
     public function addGlobalParameter($key, $value): void
     {
-        $this->globalParameters[$key] = $value;
+        $this->globalParameters->set($key, $value);
     }
 
-    public function setGlobalParameters(array $parameters): void
+    public function setGlobalParameters(ParameterBag $parameters): void
     {
         $this->globalParameters = $parameters;
     }

--- a/src/Core/PipeSynchro.php
+++ b/src/Core/PipeSynchro.php
@@ -13,6 +13,7 @@ namespace Griiv\SynchroEngine\Core;
 use Griiv\SynchroEngine\Core\DataTarget\DataTargetInterface;
 use Griiv\SynchroEngine\Core\Item\ItemDefinition;
 use Griiv\SynchroEngine\Core\Item;
+use Symfony\Component\HttpFoundation\ParameterBag;
 
 abstract class PipeSynchro extends SynchroBase
 {
@@ -34,7 +35,7 @@ abstract class PipeSynchro extends SynchroBase
      * This constructor will be called in main/child processes
      * @throws \Exception
      */
-    public function __construct($globalParameters = array())
+    public function __construct(ParameterBag $globalParameters = null)
     {
         parent::__construct($globalParameters);
 

--- a/src/Core/SequenceBase.php
+++ b/src/Core/SequenceBase.php
@@ -15,6 +15,7 @@ use Exception;
 use Griiv\SynchroEngine\Core\Helpers\SynchroHelper;
 use Griiv\SynchroEngine\Exception\BreakException;
 use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\HttpFoundation\ParameterBag;
 
 abstract class SequenceBase extends ExecutableBase
 {
@@ -35,7 +36,7 @@ abstract class SequenceBase extends ExecutableBase
     private Filesystem $fs;
 
 
-    public function __construct(array $globalParameters = [])
+    public function __construct(ParameterBag $globalParameters = null)
     {
         parent::__construct($globalParameters);
         $this->fs = new Filesystem();
@@ -171,7 +172,7 @@ abstract class SequenceBase extends ExecutableBase
         $this->getLogger()->debug(var_export($resultData, true));
     }
 
-    public function subRun($syncClassName, $syncGlobalParameters, $throwExceptionOnError)
+    public function subRun($syncClassName, ParameterBag $syncGlobalParameters, $throwExceptionOnError)
     {
         if (!class_exists($syncClassName)) {
             $this->getLogger()->warn($syncClassName . " doesn't exist");

--- a/src/Core/SynchroBase.php
+++ b/src/Core/SynchroBase.php
@@ -21,6 +21,7 @@ use Griiv\SynchroEngine\Core\Item;
 use Monolog\Handler\StreamHandler;
 use Monolog\Logger;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpFoundation\ParameterBag;
 
 abstract class SynchroBase extends ExecutableBase
 {
@@ -34,7 +35,7 @@ abstract class SynchroBase extends ExecutableBase
 
     protected ItemDefinition $itemDefinition;
 
-    public function __construct($globalParameters = array())
+    public function __construct(ParameterBag $globalParameters = null)
     {
         parent::__construct($globalParameters);
 


### PR DESCRIPTION
## Summary
- replace array-based global parameters with `ParameterBag`
- fix missing usage in `bin/batchSynchro.php`
