### PR TITLE
Run sequence synchronizations sequentially

### DIFF
--- a/src/Core/ExecutableBase.php
+++ b/src/Core/ExecutableBase.php
@@ -166,7 +166,7 @@ abstract class ExecutableBase
         return $this->throwExceptionOnError;
     }
 
-    public function execSubprocess($batchPath, $arguments)
+    public function execSubprocess($batchPath, $arguments, bool $async = true)
     {
         $result = ['status' => 'BREAK', 'data' => [], 'message' => ''];
 
@@ -181,7 +181,7 @@ abstract class ExecutableBase
         $process = Process::fromShellCommandline($cmd);
 
         $that = $this;
-        $process->start(function($type, $buffer) use ($that, $begin, $process, $beginDate) {
+        $callback = function($type, $buffer) use ($that, $begin, $process, $beginDate) {
             if (Process::ERR === $type) {
                 // Gérer la sortie d'erreur
                 $that->getLogger()->error($buffer);
@@ -210,7 +210,13 @@ abstract class ExecutableBase
 
                 $this->chunkCallback($result);
             }
-        });
+        };
+
+        if ($async) {
+            $process->start($callback);
+        } else {
+            $process->run($callback);
+        }
 
         return $process;
     }

--- a/src/Core/SequenceBase.php
+++ b/src/Core/SequenceBase.php
@@ -147,21 +147,8 @@ abstract class SequenceBase extends ExecutableBase
                 'moduleName' => $this->moduleName,
             );
 
-            $process = $this->execSubprocess($this->getBatchPath(), $arguments);
-
-            $processes[] = $process;
-        }
-
-        while (count($processes) > 0) {
-            foreach ($processes as $key => $process) {
-                // Vérifier si le processus est terminé
-                if (!$process->isRunning()) {
-                    // Supprimer le processus de la liste des processus en cours
-                    unset($processes[$key]);
-                }
-            }
-            // Attendre un court instant avant de vérifier à nouveau
-            usleep(10000); // 10 millisecondes
+            // Execute each synchronization sequentially
+            $this->execSubprocess($this->getBatchPath(), $arguments, false);
         }
 
         $this->flagAsNotRunning();


### PR DESCRIPTION
## Summary
- Add optional async flag to `execSubprocess` to support synchronous execution
- Ensure sequences invoke subprocesses sequentially rather than in parallel

## Testing
- `composer validate --no-check-all`
- `php -l src/Core/ExecutableBase.php`
- `php -l src/Core/SequenceBase.php`


------
https://chatgpt.com/codex/tasks/task_b_6898f68ca338832ab9d479ae287403cf